### PR TITLE
Add aria-pressed to toolbar buttons

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.3-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.14.3-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -298,6 +300,7 @@ GEM
 
 PLATFORMS
   aarch64-linux-musl
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/client/components/layout/FormattingToolbar.tsx
+++ b/client/components/layout/FormattingToolbar.tsx
@@ -162,6 +162,7 @@ export const FormattingToolbar = ({ editor }: FormattingToolbarProps) => {
               disabled={disabled}
               onClick={onClick}
               onMouseDown={(event) => event.preventDefault()}
+              aria-pressed={active}
             >
               <Icon
                 size="1.25em"


### PR DESCRIPTION
- M1 Mac support
- Add aria-pressed to active toolbar buttons
