### PR TITLE
Revert "[js] Update slate 0.103.0 → 0.126.0 (major)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-textarea-autosize": "^8.4.1",
     "runes": "^0.4.3",
     "scheduler": "^0.27.0",
-    "slate": "^0.126.0",
+    "slate": "^0.103.0",
     "slate-history": "^0.100.0",
     "slate-hyperscript": "^0.100.0",
     "slate-react": "^0.106.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6145,7 +6145,7 @@ __metadata:
     sass: "npm:^1.102.0"
     scheduler: "npm:^0.27.0"
     scriptjs: "npm:^2.5.9"
-    slate: "npm:^0.126.0"
+    slate: "npm:^0.103.0"
     slate-history: "npm:^0.100.0"
     slate-hyperscript: "npm:^0.100.0"
     slate-react: "npm:^0.106.0"
@@ -7485,10 +7485,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"slate@npm:^0.126.0":
-  version: 0.126.0
-  resolution: "slate@npm:0.126.0"
-  checksum: 10/26900166bd6ece00d21888da595a04ebe8f52f2967f1eb76fd1eedee48ab812bbe96173da67754f5ee1d7cc710421d6534dc73deb824a9097b47a4e4eb27a504
+"slate@npm:^0.103.0":
+  version: 0.103.0
+  resolution: "slate@npm:0.103.0"
+  dependencies:
+    immer: "npm:^10.0.3"
+    is-plain-object: "npm:^5.0.0"
+    tiny-warning: "npm:^1.0.3"
+  checksum: 10/c8d34c002049c2576d6b2fb81e89500e77186ba3d19a78b8638b5cf500eb227907b2806b2ab9345b64f4cf91e975cf9d90715b11c5b5a488d6d5092901cb3778
   languageName: node
   linkType: hard
 
@@ -7810,6 +7814,13 @@ __metadata:
   version: 1.3.1
   resolution: "tiny-invariant@npm:1.3.1"
   checksum: 10/872dbd1ff20a21303a2fd20ce3a15602cfa7fcf9b228bd694a52e2938224313b5385a1078cb667ed7375d1612194feaca81c4ecbe93121ca1baebe344de4f84c
+  languageName: node
+  linkType: hard
+
+"tiny-warning@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "tiny-warning@npm:1.0.3"
+  checksum: 10/da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Reverts 12joan/untitled-note#995, since this seems to have broken the editor