### PR TITLE
Revert "[ruby] Update redis 4.8.1 → 6.0.0 (major)"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sass-rails', '>= 6'
 gem 'vite_rails', '~> 3.11'
 
 # Use Redis for ActionCable and for caching
-gem 'redis', '~> 6.0'
+gem 'redis', '~> 4.0'
 gem 'connection_pool', '~> 3.0'
 
 # Reduces boot times through caching; required in config/boot.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,10 +296,7 @@ GEM
       rbs (>= 4.0.0)
       tsort
     redcarpet (3.6.1)
-    redis (6.0.0)
-      redis-client (= 0.30.1)
-    redis-client (0.30.1)
-      connection_pool
+    redis (4.8.1)
     regexp_parser (2.10.0)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -409,7 +406,7 @@ DEPENDENCIES
   rack_authorised_proxy
   rails (~> 8.1.3.1)
   redcarpet (~> 3.6)
-  redis (~> 6.0)
+  redis (~> 4.0)
   rexml (~> 3.4)
   sass-rails (>= 6)
   selenium-webdriver


### PR DESCRIPTION
Reverts 12joan/untitled-note#969, since it's causing problems with Action Cable